### PR TITLE
libsndfile 1.2.2 rebuild ❄️ 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,2 @@
 upload_channels:
   - sfe1ed40
-channels:
-  - https://staging.continuum.io/prefect/fs/libopus-feedstock/pr1/c45c541

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,4 @@
 #   - sfe1ed40
 channels:
   - https://staging.continuum.io/prefect/fs/libopus-feedstock/pr1/c45c541
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,4 @@
-# upload_channels:
-#   - sfe1ed40
+upload_channels:
+  - sfe1ed40
 channels:
   - https://staging.continuum.io/prefect/fs/libopus-feedstock/pr1/c45c541
-  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,4 @@
-upload_channels:
-  - sfe1ed40
+# upload_channels:
+#   - sfe1ed40
+channels:
+  - https://staging.continuum.io/prefect/fs/libopus-feedstock/pr1/c45c541

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3799ca9924d3125038880367bf1468e53a1b7e3686a934f098b7e1d286cdb80e  
 
 build:
-  number: 0
+  number: 1
   run_exports:
         # https://abi-laboratory.pro/?view=timeline&l=libsndfile
     - {{ pin_subpackage(name, max_pin="x.x") }}


### PR DESCRIPTION
libsndfile 1.2.2

**Destination channel:** Snowflake

### Links

- [PKG-5833](https://anaconda.atlassian.net/browse/PKG-5833) 
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/libopus-feedstock/pull/1
  - https://github.com/AnacondaRecipes/pysoundfile-feedstock/pull/1
  - https://github.com/AnacondaRecipes/wfdb-feedstock/pull/1

wfdb <- pysoundfile <- libsndfile <- libopus


### Explanation of changes:

- `linux aarch64` `libopus` had a package config file that had an unknown version in it. When `libsndfile` was being compiled, it had a "all or nothing" check and silently removed all of `libopus, libflak, ect` Which caused `libsndfile` on `linux aarch64` to be built incorrectly, along with `pysoundfile` and `wfdb`.


[PKG-5833]: https://anaconda.atlassian.net/browse/PKG-5833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ